### PR TITLE
Update for browsers 2024

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -88,9 +88,9 @@ export default {
      */
     container: [
       '<div class="datepicker__container">',
-        '<%= renderHeader() %>',
-        '<%= renderTimepicker() %>',
-        '<%= renderCalendar() %>',
+        '<%= obj.renderHeader() %>',
+        '<%= obj.renderTimepicker() %>',
+        '<%= obj.renderCalendar() %>',
       '</div>'
     ].join(''),
 
@@ -99,10 +99,10 @@ export default {
      */
     header: [
       '<header class="datepicker__header">',
-        '<a class="datepicker__prev<%= (hasPrev) ? "" : " is-disabled" %>" data-prev>&lsaquo;</a>',
-        '<span class="datepicker__title"><%= renderMonthSelect() %></span>',
-        '<span class="datepicker__title"><%= renderYearSelect() %></span>',
-        '<a class="datepicker__next<%= (hasNext) ? "" : " is-disabled" %>" data-next>&rsaquo;</a>',
+        '<a class="datepicker__prev<%= (obj.hasPrev) ? "" : " is-disabled" %>" data-prev>&lsaquo;</a>',
+        '<span class="datepicker__title"><%= obj.renderMonthSelect() %></span>',
+        '<span class="datepicker__title"><%= obj.renderYearSelect() %></span>',
+        '<a class="datepicker__next<%= (obj.hasNext) ? "" : " is-disabled" %>" data-next>&rsaquo;</a>',
       '</header>'
     ].join(''),
 
@@ -114,10 +114,10 @@ export default {
      */
     timepicker: [
       '<div class="datepicker__time">',
-        '<span class="datepicker__label"><%= label %></span>',
-        '<span class="datepicker__field"><%= renderHourSelect() %></span>:',
-        '<span class="datepicker__field"><%= renderMinuteSelect() %></span>',
-        '<span class="datepicker__field"><%= renderPeriodSelect() %></span>',
+        '<span class="datepicker__label"><%= obj.label %></span>',
+        '<span class="datepicker__field"><%= obj.renderHourSelect() %></span>:',
+        '<span class="datepicker__field"><%= obj.renderMinuteSelect() %></span>',
+        '<span class="datepicker__field"><%= obj.renderPeriodSelect() %></span>',
       '</div>'
     ].join(''),
 
@@ -134,15 +134,15 @@ export default {
       '<table class="datepicker__cal">',
         '<thead>',
           '<tr>',
-            '<% weekdays.forEach(function(name) { %>',
+            '<% obj.weekdays.forEach(function(name) { %>',
               '<th><%= name %></th>',
             '<% }); %>',
           '</tr>',
         '</thead>',
         '<tbody>',
-          '<% days.forEach(function(day, i) { %>',
+          '<% obj.days.forEach(function(day, i) { %>',
             '<%= (i % 7 == 0) ? "<tr>" : "" %>',
-              '<%= renderDay(day) %>',
+              '<%= obj.renderDay(day) %>',
             '<%= (i % 7 == 6) ? "</tr>" : "" %>',
           '<% }); %>',
         '</tbody>',
@@ -164,9 +164,9 @@ export default {
       * classNames - relevant `classNames`
      */
     day: [
-      '<% classNames.push("datepicker__day"); %>',
-      '<td class="<%= classNames.join(" ") %>" data-day="<%= timestamp %>"><div>',
-        '<span class="datepicker__daynum"><%= daynum %></span>',
+      '<% obj.classNames.push("datepicker__day"); %>',
+      '<td class="<%= obj.classNames.join(" ") %>" data-day="<%= obj.timestamp %>"><div>',
+        '<span class="datepicker__daynum"><%= obj.daynum %></span>',
       '</div></td>'
     ].join('')
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -168,10 +168,11 @@ export function transform(obj, fn, ctx) {
   return ret.length === 1 ? ret[0] : ret;
 }
 
-export function tmpl(str, data){
-  var fn = new Function("obj",
-    "var p=[],print=function(){p.push.apply(p,arguments);};" +
-    "with(obj){p.push('" +
+export function tmpl(str){
+
+  return new Function("obj",
+    "var p=[];" +
+    "p.push('" +
 
     str
       .replace(/[\r\t\n]/g, " ")
@@ -181,7 +182,6 @@ export function tmpl(str, data){
       .split("\t").join("');")
       .split("%>").join("p.push('")
       .split("\r").join("\\'")
-  + "');}return p.join('');");
+  + "');return p.join('');");
 
-  return data ? fn( data ) : fn;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -130,10 +130,10 @@ export default class Datepicker {
     // setup renderers
     this._renderers = {
       select: tmpl([
-        '<span style="position:relative"><%= text %>',
-          '<select data-<%= type %>="<%= value %>" data-index="<%= index %>"',
+        '<span style="position:relative"><%= obj.text %>',
+          '<select data-<%= obj.type %>="<%= obj.value %>" data-index="<%= obj.index %>"',
               'style="position:absolute;top:0;left:0;width:100%;height:100%;margin:0;opacity:0.005;cursor:pointer;">',
-            '<% options.forEach(function(o) { %>',
+            '<% obj.options.forEach(function(o) { %>',
               '<option value="<%= o.value %>"',
               '<%= o.selected ? " selected" : "" %>',
               '<%= o.disabled ? " disabled" : "" %>',


### PR DESCRIPTION
Great work @wwilsman !!!

I've made some small updates so that it works on Firefox etc.  I think it's better to use a class selector and attach onchange listeners to the `select` directly.  Previously you were waiting for the first click before attaching onchange which was breaking things on Firefox.

I also got rid of `with(obj)` in `tmpl` which makes the templating language slightly uglier but `with` is deprecated see e.g. [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with).