### PR TITLE
FixBugs for iOS Safari

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -28,7 +28,7 @@ export default {
   separator: ',',
 
   serialize(date) {
-    let dateStr = date.toLocaleDateString()
+    let dateStr = date.toLocaleDateString() ? date.toLocaleDateString() : new Date(date).toLocaleDateString()
 
     if (this.get('time')) {
       let timeStr = date.toLocaleTimeString()

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -28,10 +28,10 @@ export default {
   separator: ',',
 
   serialize(date) {
-    let dateStr = date.toLocaleDateString() ? date.toLocaleDateString() : new Date(date).toLocaleDateString()
+    let dateStr = new Date(date).toLocaleDateString()
 
     if (this.get('time')) {
-      let timeStr = date.toLocaleTimeString()
+      let timeStr = new Date(date).toLocaleTimeString()
       timeStr = timeStr.replace(/(\d{1,2}:\d{2}):00/, '$1')
       return `${dateStr}@${timeStr}`
     }


### PR DESCRIPTION
Hi @wwilsman

Fix a crash that occurs only in iOS Safari when the page is restored from the Back-Forward cache. In that scenario, the value passed to `serialize()` is no longer a `Date` instance, so` date.toLocaleDateString()` throws:
> `TypeError: date.toLocaleDateString is not a function`

**Changes**
Normalise the incoming value with `new Date(date)`

**Reproduction steps**
1. Open a page that uses Datepicker.js on iOS Safari.
2. Navigate away, then tap Back (BF-cache).
3. The picker fails to render, and the error above appears in the console.

Let me know if you'd like anything tweaked.

Thanks!
Diyah
