### PR TITLE
Set datepicker header width to auto

### DIFF
--- a/dist/css/datepicker.material.css
+++ b/dist/css/datepicker.material.css
@@ -52,6 +52,7 @@
   position: relative;
   text-align: center;
   background: #2196F3;
+  width: auto;
   padding: 0.25rem;
   margin: -0.5rem -0.5rem 0;
 }


### PR DESCRIPTION
The precedent property wasn't setted so the header background color wasn't filling the full wrapper width.